### PR TITLE
Add dynamic quant backend selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Trading Intelligence
+
+This repository contains scripts for data ingestion, feature engineering,
+model training and optimization.
+
+## Quantization Backend
+
+`optimize.py` automatically selects a quantization backend based on the
+engines available in `torch.backends.quantized.supported_engines`.
+If `fbgemm` is supported it will be used; otherwise `qnnpack` is selected.
+The chosen backend is printed when running the script.

--- a/trading_intel/optimize.py
+++ b/trading_intel/optimize.py
@@ -10,7 +10,11 @@ prune.l1_unstructured(model.lstm, name="weight_ih_l0", amount=0.5)
 prune.remove(model.lstm, 'weight_ih_l0')
 
 model.eval()
-model.qconfig = torch.quantization.get_default_qconfig('fbgemm')
+supported = torch.backends.quantized.supported_engines
+backend = 'fbgemm' if 'fbgemm' in supported else 'qnnpack'
+torch.backends.quantized.engine = backend
+print(f"Using quantization backend: {backend}")
+model.qconfig = torch.quantization.get_default_qconfig(backend)
 model_prepared = torch.quantization.prepare(model)
 model_prepared(torch.randn(1,1,3))
 model_int8 = torch.quantization.convert(model_prepared)


### PR DESCRIPTION
## Summary
- detect quantization engines with `torch.backends.quantized.supported_engines`
- prefer `fbgemm` backend when available, fall back to `qnnpack`
- document backend selection in a new README

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6879a5a80310832b9defd0839b50664d