### PR TITLE
Fix sentiment when no title present

### DIFF
--- a/trading_intel/features.py
+++ b/trading_intel/features.py
@@ -6,12 +6,21 @@ engine = sqlalchemy.create_engine(DATABASE_URL)
 vader = SentimentIntensityAnalyzer()
 
 def create_features():
-    df = pd.read_sql("SELECT * FROM price_data ORDER BY timestamp", engine)
+    query = """
+        SELECT p.*, r.title
+        FROM price_data p
+        LEFT JOIN reddit_data r
+          ON DATE_TRUNC('hour', p.timestamp) = DATE_TRUNC('hour', r.timestamp)
+        ORDER BY p.timestamp
+    """
+    df = pd.read_sql(query, engine)
     df["hour"] = df.timestamp.dt.hour
     df["price_diff"] = df.price.pct_change()
     df["ema_12"] = df.price.ewm(span=12).mean()
-    df["sentiment_score"] = df.title.apply(lambda t: vader.polarity_scores(t)["compound"])
-    df.dropna(inplace=True)
+    df["sentiment_score"] = df.title.apply(
+        lambda t: vader.polarity_scores(t)["compound"] if isinstance(t, str) and t else 0.0
+    )
+    df.dropna(subset=["price_diff", "ema_12"], inplace=True)
     df.to_sql("features", engine, if_exists="replace", index=False)
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- join Reddit data when generating features
- compute sentiment only for rows with a title
- drop NA rows based on price-derived features only

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6879a5a88ee0832bbf037d0d9b26ca9a