### PR TITLE
Make cron path configurable, avoid shell

### DIFF
--- a/trading_intel/cli.py
+++ b/trading_intel/cli.py
@@ -1,23 +1,44 @@
 #!/usr/bin/env python3
-import subprocess, sys, os
+import subprocess, sys, shutil
+from config import PROJECT_DIR
 
-def start():
-    subprocess.run("(crontab -l 2>/dev/null; echo '@hourly cd ~/trading_intel && python inference.py >> inference.log 2>&1') | crontab -", shell=True)
+def _check_cron():
+    if not shutil.which("crontab"):
+        raise EnvironmentError("'crontab' command not found. Is cron installed?")
+
+def start(path=None):
+    _check_cron()
+    path = path or PROJECT_DIR
+    current = subprocess.run(["crontab", "-l"], capture_output=True, text=True)
+    cron = current.stdout if current.returncode == 0 else ""
+    entry = f"@hourly cd {path} && python inference.py >> inference.log 2>&1"
+    if entry not in cron:
+        if cron and not cron.endswith("\n"):
+            cron += "\n"
+        cron += entry + "\n"
+    subprocess.run(["crontab", "-"], input=cron, text=True, check=True)
     print("✅ Scheduled hourly inference (crontab added).")
 
 def stop():
-    subprocess.run("crontab -l | grep -v 'inference.py' | crontab -", shell=True)
+    _check_cron()
+    current = subprocess.run(["crontab", "-l"], capture_output=True, text=True)
+    cron = current.stdout if current.returncode == 0 else ""
+    new_cron = "\n".join(
+        line for line in cron.splitlines() if "inference.py" not in line
+    )
+    subprocess.run(["crontab", "-"], input=new_cron + "\n", text=True, check=True)
     print("🛑 Stopped hourly inference.")
 
 def status():
-    out = subprocess.run("crontab -l", shell=True, capture_output=True, text=True)
+    _check_cron()
+    out = subprocess.run(["crontab", "-l"], capture_output=True, text=True, check=True)
     print("📋 Crontab:\n", out.stdout)
 
 if __name__=="__main__":
     if len(sys.argv)<2:
-        print("usage: cli.py [start|stop|status]")
+        print("usage: cli.py [start|stop|status] [path]")
     elif sys.argv[1]=="start":
-        start()
+        start(sys.argv[2] if len(sys.argv) > 2 else None)
     elif sys.argv[1]=="stop":
         stop()
     else:

--- a/trading_intel/config.py
+++ b/trading_intel/config.py
@@ -3,6 +3,7 @@ from dotenv import load_dotenv
 load_dotenv()
 
 DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://localhost/trading_intelligence")
+PROJECT_DIR = os.getenv("TRADING_INTEL_DIR", os.path.dirname(os.path.abspath(__file__)))
 API_KEYS = {
     "ALPHA_VANTAGE": os.getenv("ALPHA_VANTAGE_API_KEY", ""),
     "FRED": os.getenv("FRED_API_KEY", ""),


### PR DESCRIPTION
## Summary
- load `PROJECT_DIR` from environment
- rewrite cron jobs to not use `shell=True`
- check for cron availability and allow optional path argument

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6879a5a8a2b4832b9da79800ed31697f