### PR TITLE
Improve error handling and add tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.0.0
+    hooks:
+      - id: flake8

--- a/README.md
+++ b/README.md
@@ -63,3 +63,19 @@ python trading_intel/cli.py start   # add to crontab
 python trading_intel/cli.py stop    # remove from crontab
 ```
 
+## Development
+
+### Formatting
+Run `pre-commit` to automatically format and lint the code:
+
+```bash
+pre-commit run --all-files
+```
+
+### Testing
+Execute the unit tests with `pytest`:
+
+```bash
+pytest
+```
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ numpy
 sqlalchemy
 psycopg2-binary
 requests
-ccxt
 alpha_vantage
 praw
 web3
@@ -13,3 +12,8 @@ vaderSentiment
 scikit-learn
 torch
 onnxruntime
+pytest
+black
+flake8
+isort
+pre-commit

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,48 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))  # noqa: E402
+
+import importlib  # noqa: E402
+
+import pytest  # noqa: E402
+
+import trading_intel.config as config  # noqa: E402
+
+
+def reload_config(monkeypatch, env):
+    for k, v in env.items():
+        if v is None:
+            monkeypatch.delenv(k, raising=False)
+        else:
+            monkeypatch.setenv(k, v)
+    return importlib.reload(config)
+
+
+def test_validate_env_missing(monkeypatch):
+    conf = reload_config(
+        monkeypatch,
+        {
+            "DATABASE_URL": None,
+            "ALPHA_VANTAGE_API_KEY": None,
+            "FRED_API_KEY": None,
+            "REDDIT_CLIENT_ID": None,
+            "REDDIT_CLIENT_SECRET": None,
+        },
+    )
+    with pytest.raises(RuntimeError):
+        conf.validate_env()
+
+
+def test_validate_env_present(monkeypatch):
+    conf = reload_config(
+        monkeypatch,
+        {
+            "DATABASE_URL": "sqlite:///:memory:",
+            "ALPHA_VANTAGE_API_KEY": "x",
+            "FRED_API_KEY": "x",
+            "REDDIT_CLIENT_ID": "x",
+            "REDDIT_CLIENT_SECRET": "x",
+        },
+    )
+    conf.validate_env()

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -1,0 +1,35 @@
+import os
+import sys
+
+import pandas as pd
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))  # noqa: E402
+os.environ.setdefault("ALPHA_VANTAGE_API_KEY", "test")
+os.environ.setdefault("ALPHAVANTAGE_API_KEY", "test")
+import importlib  # noqa: E402
+
+import trading_intel.config as config  # noqa: E402
+
+importlib.reload(config)  # ensure env var picked up
+from trading_intel import ingestion  # noqa: E402
+
+
+def test_fetch_crypto_error(monkeypatch):
+    def fail(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(ingestion.requests, "get", fail)
+    df = ingestion.fetch_crypto()
+    assert isinstance(df, pd.DataFrame)
+    assert df.empty
+
+
+def test_fetch_stock_error(monkeypatch):
+    class DummyTS:
+        def get_intraday(self, *args, **kwargs):
+            raise RuntimeError("fail")
+
+    monkeypatch.setattr(ingestion, "ts", DummyTS())
+    df = ingestion.fetch_stock()
+    assert isinstance(df, pd.DataFrame)
+    assert df.empty

--- a/trading_intel/cli.py
+++ b/trading_intel/cli.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
-import subprocess, sys, os, logging
-from config import LOG_FILE
+import logging
+import subprocess
+import sys
+
+from .config import LOG_FILE
 
 logging.basicConfig(
     level=logging.INFO,
@@ -9,27 +12,38 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
+
 def start():
-    subprocess.run(
-        "(crontab -l 2>/dev/null; echo '@hourly cd ~/trading_intel && python inference.py >> inference.log 2>&1') | crontab -",
-        shell=True,
+    cmd = (
+        "(crontab -l 2>/dev/null; echo '@hourly cd ~/trading_intel && python "
+        "inference.py >> inference.log 2>&1') | crontab -"
     )
+    subprocess.run(cmd, shell=True)
     logger.info("\u2705 Scheduled hourly inference (crontab added).")
 
+
 def stop():
-    subprocess.run("crontab -l | grep -v 'inference.py' | crontab -", shell=True)
-    logger.info("\U0001F6D1 Stopped hourly inference.")
+    cmd = "crontab -l | grep -v 'inference.py' | crontab -"
+    subprocess.run(cmd, shell=True)
+    logger.info("\U0001f6d1 Stopped hourly inference.")
+
 
 def status():
-    out = subprocess.run("crontab -l", shell=True, capture_output=True, text=True)
-    logger.info("\U0001F4CB Crontab:\n%s", out.stdout)
+    out = subprocess.run(
+        "crontab -l",
+        shell=True,
+        capture_output=True,
+        text=True,
+    )
+    logger.info("\U0001f4cb Crontab:\n%s", out.stdout)
 
-if __name__=="__main__":
-    if len(sys.argv)<2:
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
         logger.error("usage: cli.py [start|stop|status]")
-    elif sys.argv[1]=="start":
+    elif sys.argv[1] == "start":
         start(sys.argv[2] if len(sys.argv) > 2 else None)
-    elif sys.argv[1]=="stop":
+    elif sys.argv[1] == "stop":
         stop()
     else:
         status()

--- a/trading_intel/config.py
+++ b/trading_intel/config.py
@@ -1,16 +1,24 @@
 import os
+
 from dotenv import load_dotenv
 
 load_dotenv()
 
-DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://localhost/trading_intelligence")
-PROJECT_DIR = os.getenv("TRADING_INTEL_DIR", os.path.dirname(os.path.abspath(__file__)))
+DATABASE_URL = os.getenv(
+    "DATABASE_URL",
+    "postgresql://localhost/trading_intelligence",
+)
+PROJECT_DIR = os.getenv(
+    "TRADING_INTEL_DIR",
+    os.path.dirname(os.path.abspath(__file__)),
+)
 API_KEYS = {
     "ALPHA_VANTAGE": os.getenv("ALPHA_VANTAGE_API_KEY", ""),
     "FRED": os.getenv("FRED_API_KEY", ""),
     "REDDIT_CLIENT_ID": os.getenv("REDDIT_CLIENT_ID", ""),
     "REDDIT_CLIENT_SECRET": os.getenv("REDDIT_CLIENT_SECRET", ""),
 }
+
 
 def validate_env() -> None:
     """Ensure all critical environment variables are present.
@@ -38,7 +46,6 @@ def validate_env() -> None:
             "Set them in your environment or in a '.env' file."
         )
 
-=======
+
 # Optional log file path for logging.basicConfig
 LOG_FILE = os.getenv("LOG_FILE", "")
-

--- a/trading_intel/features.py
+++ b/trading_intel/features.py
@@ -1,6 +1,10 @@
-import pandas as pd, numpy as np, sqlalchemy, networkx as nx, logging
+import logging
+
+import pandas as pd
+import sqlalchemy
 from vaderSentiment.vaderSentiment import SentimentIntensityAnalyzer
-from config import DATABASE_URL, LOG_FILE
+
+from .config import DATABASE_URL, LOG_FILE
 
 logging.basicConfig(
     level=logging.INFO,
@@ -12,6 +16,15 @@ logger = logging.getLogger(__name__)
 
 engine = sqlalchemy.create_engine(DATABASE_URL)
 vader = SentimentIntensityAnalyzer()
+
+
+def _sentiment(text: str) -> float:
+    return (
+        vader.polarity_scores(text)["compound"]
+        if isinstance(text, str) and text
+        else 0.0
+    )
+
 
 def create_features():
     query = """
@@ -25,12 +38,11 @@ def create_features():
     df["hour"] = df.timestamp.dt.hour
     df["price_diff"] = df.price.pct_change()
     df["ema_12"] = df.price.ewm(span=12).mean()
-    df["sentiment_score"] = df.title.apply(
-        lambda t: vader.polarity_scores(t)["compound"] if isinstance(t, str) and t else 0.0
-    )
+    df["sentiment_score"] = df.title.apply(_sentiment)
     df.dropna(subset=["price_diff", "ema_12"], inplace=True)
     df.to_sql("features", engine, if_exists="replace", index=False)
     logger.info("Features table created with %d rows", len(df))
+
 
 if __name__ == "__main__":
     create_features()

--- a/trading_intel/inference.py
+++ b/trading_intel/inference.py
@@ -1,8 +1,13 @@
-import onnxruntime as ort, numpy as np, logging
-from ingestion import fetch_crypto, fetch_reddit, fetch_stock, fetch_eth_chain
-from features import create_features
-from config import DATABASE_URL, LOG_FILE
-import sqlalchemy, time
+import logging
+import time
+
+import numpy as np
+import onnxruntime as ort
+import sqlalchemy
+
+from .config import DATABASE_URL, LOG_FILE
+from .features import create_features
+from .ingestion import fetch_crypto, fetch_eth_chain, fetch_reddit, fetch_stock
 
 logging.basicConfig(
     level=logging.INFO,
@@ -16,10 +21,17 @@ sess = ort.InferenceSession("lstm_model.onnx")
 
 while True:
     t0 = time.time()
-    fetch_crypto(); fetch_stock(); fetch_eth_chain(); fetch_reddit()
+    fetch_crypto()
+    fetch_stock()
+    fetch_eth_chain()
+    fetch_reddit()
     create_features()
     df = sqlalchemy.read_sql("features", engine).iloc[-1:]
-    X = np.expand_dims(df[["price_diff","ema_12","sentiment_score"]].values.astype(np.float32), axis=1)
+    features = ["price_diff", "ema_12", "sentiment_score"]
+    X = np.expand_dims(
+        df[features].values.astype(np.float32),
+        axis=1,
+    )
     pred = sess.run(None, {"input": X})[0].squeeze()
     logger.info("%s \u2192 Prediction: %s", time.asctime(), pred)
     time.sleep(max(0, 3600 - (time.time() - t0)))

--- a/trading_intel/ingestion.py
+++ b/trading_intel/ingestion.py
@@ -1,10 +1,14 @@
-import ccxt, requests, pandas as pd, sqlalchemy, logging
+import logging
+from datetime import datetime
+
+import pandas as pd
+import requests
+import sqlalchemy
 from alpha_vantage.timeseries import TimeSeries
 from praw import Reddit
 from web3 import Web3
-from datetime import datetime
-from psycopg2 import sql
-from config import DATABASE_URL, API_KEYS, LOG_FILE
+
+from .config import API_KEYS, DATABASE_URL, LOG_FILE
 
 logging.basicConfig(
     level=logging.INFO,
@@ -14,45 +18,122 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 engine = sqlalchemy.create_engine(DATABASE_URL)
-ts = TimeSeries(key=API_KEYS["ALPHA_VANTAGE"], output_format='pandas')
-reddit = Reddit(client_id=API_KEYS["REDDIT_CLIENT_ID"],
-                client_secret=API_KEYS["REDDIT_CLIENT_SECRET"],
-                user_agent="ti-app")
+ts = TimeSeries(key=API_KEYS["ALPHA_VANTAGE"], output_format="pandas")
+reddit = Reddit(
+    client_id=API_KEYS["REDDIT_CLIENT_ID"],
+    client_secret=API_KEYS["REDDIT_CLIENT_SECRET"],
+    user_agent="ti-app",
+)
+
+
+def _handle_error(msg: str, exc: Exception) -> None:
+    """Log the error message and exception details."""
+    logger.error("%s: %s", msg, exc)
+
 
 # Crypto
-def fetch_crypto(coin="bitcoin", vs="usd"):
+def fetch_crypto(coin: str = "bitcoin", vs: str = "usd") -> pd.DataFrame:
+    """Fetch recent cryptocurrency prices from CoinGecko.
+
+    Returns an empty ``DataFrame`` on failure.
+    """
     url = f"https://api.coingecko.com/api/v3/coins/{coin}/market_chart"
-    resp = requests.get(url, params={"vs_currency": vs, "days": "7"})
-    df = pd.DataFrame(resp.json()["prices"], columns=["timestamp", "price"])
-    df["timestamp"] = pd.to_datetime(df["timestamp"], unit="ms")
-    df["type"] = "crypto"; df["symbol"] = coin
-    df.to_sql("price_data", engine, if_exists="append", index=False)
-    logger.info("Fetched crypto data for %s", coin)
+    try:
+        resp = requests.get(
+            url,
+            params={"vs_currency": vs, "days": "7"},
+            timeout=10,
+        )
+        resp.raise_for_status()
+        df = pd.DataFrame(
+            resp.json()["prices"], columns=["timestamp", "price"]
+        )  # noqa: E501
+        df["timestamp"] = pd.to_datetime(df["timestamp"], unit="ms")
+        df["type"] = "crypto"
+        df["symbol"] = coin
+        df.to_sql("price_data", engine, if_exists="append", index=False)
+        logger.info("Fetched crypto data for %s", coin)
+        return df
+    except Exception as exc:  # noqa: BLE001
+        _handle_error("Failed to fetch crypto data", exc)
+        return pd.DataFrame()
+
 
 # Stocks
-def fetch_stock(symbol="AAPL"):
-    df, _ = ts.get_intraday(symbol, interval='60min', outputsize='compact')
-    df.reset_index(inplace=True)
-    df.rename(columns={"date":"timestamp","open":"open","high":"high","low":"low","close":"close","volume":"volume"}, inplace=True)
-    df["symbol"] = symbol; df["type"] = "stock"
-    df.to_sql("price_data", engine, if_exists="append", index=False)
-    logger.info("Fetched stock data for %s", symbol)
+def fetch_stock(symbol: str = "AAPL") -> pd.DataFrame:
+    """Fetch hourly stock data using Alpha Vantage."""
+    try:
+        df, _ = ts.get_intraday(symbol, interval="60min", outputsize="compact")
+        df.reset_index(inplace=True)
+        df.rename(
+            columns={
+                "date": "timestamp",
+                "open": "open",
+                "high": "high",
+                "low": "low",
+                "close": "close",
+                "volume": "volume",
+            },
+            inplace=True,
+        )
+        df["symbol"] = symbol
+        df["type"] = "stock"
+        df.to_sql("price_data", engine, if_exists="append", index=False)
+        logger.info("Fetched stock data for %s", symbol)
+        return df
+    except Exception as exc:  # noqa: BLE001
+        _handle_error(f"Failed to fetch stock data for {symbol}", exc)
+        return pd.DataFrame()
+
 
 # On-chain (Ethereum)
-def fetch_eth_chain():
-    w3 = Web3(Web3.HTTPProvider("https://cloudflare-eth.com"))
-    block = w3.eth.get_block("latest")
-    df = pd.DataFrame([{**dict(block), "timestamp": datetime.utcfromtimestamp(block.timestamp), "symbol":"ETH", "type":"onchain"}])
-    df.to_sql("onchain_data", engine, if_exists="append", index=False)
-    logger.info("Fetched latest Ethereum block")
+def fetch_eth_chain() -> pd.DataFrame:
+    """Fetch the latest Ethereum block information."""
+    try:
+        w3 = Web3(Web3.HTTPProvider("https://cloudflare-eth.com"))
+        block = w3.eth.get_block("latest")
+        df = pd.DataFrame(
+            [
+                {
+                    **dict(block),
+                    "timestamp": datetime.utcfromtimestamp(block.timestamp),
+                    "symbol": "ETH",
+                    "type": "onchain",
+                }
+            ]
+        )
+        df.to_sql("onchain_data", engine, if_exists="append", index=False)
+        logger.info("Fetched latest Ethereum block")
+        return df
+    except Exception as exc:  # noqa: BLE001
+        _handle_error("Failed to fetch Ethereum block", exc)
+        return pd.DataFrame()
+
 
 # Reddit
-def fetch_reddit(sub="CryptoCurrency", limit=50):
-    posts = reddit.subreddit(sub).new(limit=limit)
-    df = pd.DataFrame([{"id":p.id,"timestamp":datetime.utcfromtimestamp(p.created_utc),
-                        "title":p.title, "selftext":p.selftext, "sub":sub} for p in posts])
-    df.to_sql("reddit_data", engine, if_exists="append", index=False)
-    logger.info("Fetched %d Reddit posts from %s", len(df), sub)
+def fetch_reddit(sub: str = "CryptoCurrency", limit: int = 50) -> pd.DataFrame:
+    """Fetch recent Reddit submissions from ``sub``."""
+    try:
+        posts = reddit.subreddit(sub).new(limit=limit)
+        df = pd.DataFrame(
+            [
+                {
+                    "id": p.id,
+                    "timestamp": datetime.utcfromtimestamp(p.created_utc),
+                    "title": p.title,
+                    "selftext": p.selftext,
+                    "sub": sub,
+                }
+                for p in posts
+            ]
+        )
+        df.to_sql("reddit_data", engine, if_exists="append", index=False)
+        logger.info("Fetched %d Reddit posts from %s", len(df), sub)
+        return df
+    except Exception as exc:  # noqa: BLE001
+        _handle_error(f"Failed to fetch Reddit posts from {sub}", exc)
+        return pd.DataFrame()
+
 
 if __name__ == "__main__":
     fetch_crypto()

--- a/trading_intel/modeling.py
+++ b/trading_intel/modeling.py
@@ -1,8 +1,12 @@
-import torch, torch.nn as nn, logging
+import logging
+
 import pandas as pd
-from sklearn.model_selection import train_test_split
-from config import DATABASE_URL, LOG_FILE
 import sqlalchemy
+import torch
+import torch.nn as nn
+from sklearn.model_selection import train_test_split
+
+from .config import DATABASE_URL, LOG_FILE
 
 logging.basicConfig(
     level=logging.INFO,
@@ -13,23 +17,29 @@ logger = logging.getLogger(__name__)
 
 engine = sqlalchemy.create_engine(DATABASE_URL)
 
+
 class SimpleLSTM(nn.Module):
     def __init__(self, input_dim):
         super().__init__()
         self.lstm = nn.LSTM(input_dim, 32, batch_first=True)
         self.fc = nn.Linear(32, 1)
+
     def forward(self, x):
         return self.fc(self.lstm(x)[0][:, -1, :])
 
+
 def train():
     df = pd.read_sql("features", engine)
-    X = df[["price_diff","ema_12","sentiment_score"]].values
+    X = df[["price_diff", "ema_12", "sentiment_score"]].values
     y = df["price_diff"].shift(-1).fillna(0).values
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, shuffle=False)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.2, shuffle=False
+    )
     X_train = torch.FloatTensor(X_train).unsqueeze(1)
     y_train = torch.FloatTensor(y_train)
     model = SimpleLSTM(X_train.shape[-1])
-    criterion, optimizer = nn.MSELoss(), torch.optim.Adam(model.parameters(), lr=1e-3)
+    criterion = nn.MSELoss()
+    optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
     for epoch in range(50):
         model.train()
         optimizer.zero_grad()
@@ -37,7 +47,8 @@ def train():
         loss.backward()
         optimizer.step()
     torch.save(model.state_dict(), "lstm.pth")
-    logger.info("\U0001F389 Model trained, loss: %s", loss.item())
+    logger.info("\U0001f389 Model trained, loss: %s", loss.item())
+
 
 if __name__ == "__main__":
     train()

--- a/trading_intel/optimize.py
+++ b/trading_intel/optimize.py
@@ -1,7 +1,11 @@
-import torch, torch.nn.utils.prune as prune, torch.quantization, logging
-from modeling import SimpleLSTM
-import numpy as np
-from config import LOG_FILE
+import logging
+
+import torch
+import torch.nn.utils.prune as prune
+import torch.quantization
+
+from .config import LOG_FILE
+from .modeling import SimpleLSTM
 
 logging.basicConfig(
     level=logging.INFO,
@@ -15,18 +19,18 @@ model = SimpleLSTM(input_dim=3)
 model.load_state_dict(state)
 
 prune.l1_unstructured(model.lstm, name="weight_ih_l0", amount=0.5)
-prune.remove(model.lstm, 'weight_ih_l0')
+prune.remove(model.lstm, "weight_ih_l0")
 
 model.eval()
 supported = torch.backends.quantized.supported_engines
-backend = 'fbgemm' if 'fbgemm' in supported else 'qnnpack'
+backend = "fbgemm" if "fbgemm" in supported else "qnnpack"
 torch.backends.quantized.engine = backend
 print(f"Using quantization backend: {backend}")
 model.qconfig = torch.quantization.get_default_qconfig(backend)
 model_prepared = torch.quantization.prepare(model)
-model_prepared(torch.randn(1,1,3))
+model_prepared(torch.randn(1, 1, 3))
 model_int8 = torch.quantization.convert(model_prepared)
 
-dummy = torch.randn(1,1,3)
+dummy = torch.randn(1, 1, 3)
 torch.onnx.export(model_int8, dummy, "lstm_model.onnx", opset_version=13)
 logger.info("\u2705 ONNX export complete.")


### PR DESCRIPTION
## Summary
- add development section to README
- handle API errors in `ingestion.py`
- switch to package-relative imports
- set up formatting with pre-commit
- add unit tests for config validation and ingestion

## Testing
- `flake8 trading_intel tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879b9d64624832bb205dd11737da1ed