### PR TITLE
Implement retries with backoff for ingestion

### DIFF
--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -25,11 +25,10 @@ def test_fetch_crypto_error(monkeypatch):
 
 
 def test_fetch_stock_error(monkeypatch):
-    class DummyTS:
-        def get_intraday(self, *args, **kwargs):
-            raise RuntimeError("fail")
+    def fail(*args, **kwargs):
+        raise RuntimeError("fail")
 
-    monkeypatch.setattr(ingestion, "ts", DummyTS())
+    monkeypatch.setattr(ingestion.requests, "get", fail)
     df = ingestion.fetch_stock()
     assert isinstance(df, pd.DataFrame)
     assert df.empty


### PR DESCRIPTION
## Summary
- add exponential backoff retry logic to stock, ethereum, and reddit data fetchers
- refactor stock API call to use `requests.get` with timeout
- log failures for each retry attempt
- update tests for new stock ingest behavior

## Testing
- `pre-commit run --files trading_intel/ingestion.py tests/test_ingestion.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879c307fa34832b93094a80d34031e3