### PR TITLE
Fix inference feature row read

### DIFF
--- a/trading_intel/inference.py
+++ b/trading_intel/inference.py
@@ -3,6 +3,7 @@ import time
 
 import numpy as np
 import onnxruntime as ort
+import pandas as pd
 import sqlalchemy
 
 from .config import DATABASE_URL, LOG_FILE
@@ -26,7 +27,7 @@ while True:
     fetch_eth_chain()
     fetch_reddit()
     create_features()
-    df = sqlalchemy.read_sql("features", engine).iloc[-1:]
+    df = pd.read_sql("features", engine).iloc[-1:]
     features = ["price_diff", "ema_12", "sentiment_score"]
     X = np.expand_dims(
         df[features].values.astype(np.float32),


### PR DESCRIPTION
## Summary
- use `pandas.read_sql` instead of `sqlalchemy.read_sql` when retrieving the latest features row

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6879c308ffa4832b8c9a5a14f317c82e