### PR TITLE
Fix CLI path handling

### DIFF
--- a/trading_intel/cli.py
+++ b/trading_intel/cli.py
@@ -2,6 +2,7 @@
 import logging
 import subprocess
 import sys
+from pathlib import Path
 
 from .config import LOG_FILE
 
@@ -14,9 +15,11 @@ logger = logging.getLogger(__name__)
 
 
 def start():
+    project_dir = Path(__file__).resolve().parent
     cmd = (
-        "(crontab -l 2>/dev/null; echo '@hourly cd ~/trading_intel && python "
-        "inference.py >> inference.log 2>&1') | crontab -"
+        "(crontab -l 2>/dev/null; echo '@hourly cd "
+        f"{project_dir} && {sys.executable} inference.py "
+        ">> inference.log 2>&1') | crontab -"
     )
     subprocess.run(cmd, shell=True)
     logger.info("\u2705 Scheduled hourly inference (crontab added).")


### PR DESCRIPTION
## Summary
- fix path handling in trading_intel CLI
- ensure crontab uses running Python executable

## Testing
- `pre-commit run --files trading_intel/cli.py`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879c99b18f0832b9506ae0c391838b4