### PR TITLE
Use consistent paths for trained models

### DIFF
--- a/trading_intel/inference.py
+++ b/trading_intel/inference.py
@@ -1,5 +1,6 @@
 import logging
 import time
+from pathlib import Path
 
 import numpy as np
 import onnxruntime as ort
@@ -18,7 +19,8 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 engine = sqlalchemy.create_engine(DATABASE_URL)
-sess = ort.InferenceSession("lstm_model.onnx")
+onnx_path = Path(__file__).resolve().parent / "lstm_model.onnx"
+sess = ort.InferenceSession(str(onnx_path))
 
 while True:
     t0 = time.time()

--- a/trading_intel/modeling.py
+++ b/trading_intel/modeling.py
@@ -1,4 +1,5 @@
 import logging
+from pathlib import Path
 
 import pandas as pd
 import sqlalchemy
@@ -16,6 +17,7 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 engine = sqlalchemy.create_engine(DATABASE_URL)
+lstm_path = Path(__file__).resolve().parent / "lstm.pth"
 
 
 class SimpleLSTM(nn.Module):
@@ -46,7 +48,7 @@ def train():
         loss = criterion(model(X_train).squeeze(), y_train)
         loss.backward()
         optimizer.step()
-    torch.save(model.state_dict(), "lstm.pth")
+    torch.save(model.state_dict(), lstm_path)
     logger.info("\U0001f389 Model trained, loss: %s", loss.item())
 
 

--- a/trading_intel/optimize.py
+++ b/trading_intel/optimize.py
@@ -1,4 +1,5 @@
 import logging
+from pathlib import Path
 
 import torch
 import torch.nn.utils.prune as prune
@@ -14,7 +15,8 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-state = torch.load("lstm.pth")
+base_dir = Path(__file__).resolve().parent
+state = torch.load(base_dir / "lstm.pth")
 model = SimpleLSTM(input_dim=3)
 model.load_state_dict(state)
 
@@ -32,5 +34,5 @@ model_prepared(torch.randn(1, 1, 3))
 model_int8 = torch.quantization.convert(model_prepared)
 
 dummy = torch.randn(1, 1, 3)
-torch.onnx.export(model_int8, dummy, "lstm_model.onnx", opset_version=13)
+torch.onnx.export(model_int8, dummy, base_dir / "lstm_model.onnx", opset_version=13)
 logger.info("\u2705 ONNX export complete.")


### PR DESCRIPTION
## Summary
- load/save models relative to script location so scripts can run from anywhere

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879c99be670832b80c591130df485e6