### PR TITLE
Add packaging config

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,13 @@ model training and optimization.
 engines available in `torch.backends.quantized.supported_engines`.
 If `fbgemm` is supported it will be used; otherwise `qnnpack` is selected.
 The chosen backend is printed when running the script.
-=======
 This project ingests price and social sentiment data, builds features, trains a model and exposes an inference loop.  
 
 ## Setup
 1. Install Python 3 and `pip`.
-2. Install dependencies:
+2. Install the package in editable mode along with dependencies:
    ```bash
-   pip install -r requirements.txt
+   pip install -e .
    ```
 3. Configure environment variables. You can place them in a `.env` file in the project root:
    ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,32 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "trading_intel"
+version = "0.1.0"
+description = "Trading intelligence scripts"
+readme = "README.md"
+requires-python = ">=3.8"
+
+# runtime dependencies
+dependencies = [
+    "pandas",
+    "numpy",
+    "sqlalchemy",
+    "psycopg2-binary",
+    "requests",
+    "alpha_vantage",
+    "praw",
+    "web3",
+    "python-dotenv",
+    "networkx",
+    "vaderSentiment",
+    "scikit-learn",
+    "torch",
+    "onnxruntime",
+    "pytest",
+]
+
+[tool.setuptools]
+packages = ["trading_intel"]


### PR DESCRIPTION
## Summary
- package `trading_intel` with pyproject
- document editable install for running tests and scripts

## Testing
- `pip install -e .` *(fails: ModuleNotFoundError during tests)*

------
https://chatgpt.com/codex/tasks/task_e_6879c99c8580832b903875267077c8af