### PR TITLE
Handle missing ONNX model

### DIFF
--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1,0 +1,17 @@
+import importlib
+import logging
+from pathlib import Path
+
+import pytest
+
+
+def test_missing_model(monkeypatch, caplog):
+    caplog.set_level(logging.ERROR)
+
+    def always_false(self):
+        return False
+
+    monkeypatch.setattr(Path, "exists", always_false)
+    with pytest.raises(SystemExit):
+        importlib.reload(importlib.import_module("trading_intel.inference"))
+    assert "ONNX model not found" in caplog.text

--- a/trading_intel/inference.py
+++ b/trading_intel/inference.py
@@ -20,6 +20,9 @@ logger = logging.getLogger(__name__)
 
 engine = sqlalchemy.create_engine(DATABASE_URL)
 onnx_path = Path(__file__).resolve().parent / "lstm_model.onnx"
+if not onnx_path.exists():
+    logger.error("ONNX model not found at %s", onnx_path)
+    raise SystemExit(1)
 sess = ort.InferenceSession(str(onnx_path))
 
 while True:


### PR DESCRIPTION
## Summary
- stop inference if ONNX model isn't present
- test inference exit when the model is missing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879d411cf14832bbb1380943db0b5be