### PR TITLE
Centralize logging setup

### DIFF
--- a/trading_intel/cli.py
+++ b/trading_intel/cli.py
@@ -4,13 +4,8 @@ import subprocess
 import sys
 from pathlib import Path
 
-from .config import LOG_FILE
+from .logging_utils import setup_logging
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
-    filename=LOG_FILE if LOG_FILE else None,
-)
 logger = logging.getLogger(__name__)
 
 
@@ -42,6 +37,7 @@ def status():
 
 
 if __name__ == "__main__":
+    setup_logging()
     if len(sys.argv) < 2:
         logger.error("usage: cli.py [start|stop|status]")
     elif sys.argv[1] == "start":

--- a/trading_intel/features.py
+++ b/trading_intel/features.py
@@ -4,13 +4,9 @@ import pandas as pd
 import sqlalchemy
 from vaderSentiment.vaderSentiment import SentimentIntensityAnalyzer
 
-from .config import DATABASE_URL, LOG_FILE
+from .config import DATABASE_URL
+from .logging_utils import setup_logging
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
-    filename=LOG_FILE if LOG_FILE else None,
-)
 logger = logging.getLogger(__name__)
 
 
@@ -45,4 +41,5 @@ def create_features():
 
 
 if __name__ == "__main__":
+    setup_logging()
     create_features()

--- a/trading_intel/inference.py
+++ b/trading_intel/inference.py
@@ -7,34 +7,37 @@ import onnxruntime as ort
 import pandas as pd
 import sqlalchemy
 
-from .config import DATABASE_URL, LOG_FILE
+from .config import DATABASE_URL
 from .features import create_features
 from .ingestion import fetch_crypto, fetch_eth_chain, fetch_reddit, fetch_stock
+from .logging_utils import setup_logging
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
-    filename=LOG_FILE if LOG_FILE else None,
-)
 logger = logging.getLogger(__name__)
 
 engine = sqlalchemy.create_engine(DATABASE_URL)
 onnx_path = Path(__file__).resolve().parent / "lstm_model.onnx"
 sess = ort.InferenceSession(str(onnx_path))
 
-while True:
-    t0 = time.time()
-    fetch_crypto()
-    fetch_stock()
-    fetch_eth_chain()
-    fetch_reddit()
-    create_features()
-    df = pd.read_sql("features", engine).iloc[-1:]
-    features = ["price_diff", "ema_12", "sentiment_score"]
-    X = np.expand_dims(
-        df[features].values.astype(np.float32),
-        axis=1,
-    )
-    pred = sess.run(None, {"input": X})[0].squeeze()
-    logger.info("%s \u2192 Prediction: %s", time.asctime(), pred)
-    time.sleep(max(0, 3600 - (time.time() - t0)))
+
+def main() -> None:
+    while True:
+        t0 = time.time()
+        fetch_crypto()
+        fetch_stock()
+        fetch_eth_chain()
+        fetch_reddit()
+        create_features()
+        df = pd.read_sql("features", engine).iloc[-1:]
+        features = ["price_diff", "ema_12", "sentiment_score"]
+        X = np.expand_dims(
+            df[features].values.astype(np.float32),
+            axis=1,
+        )
+        pred = sess.run(None, {"input": X})[0].squeeze()
+        logger.info("%s \u2192 Prediction: %s", time.asctime(), pred)
+        time.sleep(max(0, 3600 - (time.time() - t0)))
+
+
+if __name__ == "__main__":
+    setup_logging()
+    main()

--- a/trading_intel/ingestion.py
+++ b/trading_intel/ingestion.py
@@ -9,13 +9,9 @@ from alpha_vantage.timeseries import TimeSeries
 from praw import Reddit
 from web3 import Web3
 
-from .config import API_KEYS, DATABASE_URL, LOG_FILE
+from .config import API_KEYS, DATABASE_URL
+from .logging_utils import setup_logging
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
-    filename=LOG_FILE if LOG_FILE else None,
-)
 logger = logging.getLogger(__name__)
 
 engine = sqlalchemy.create_engine(DATABASE_URL)
@@ -200,6 +196,7 @@ def fetch_reddit(sub: str = "CryptoCurrency", limit: int = 50) -> pd.DataFrame:
 
 
 if __name__ == "__main__":
+    setup_logging()
     fetch_crypto()
     fetch_stock()
     fetch_eth_chain()

--- a/trading_intel/logging_utils.py
+++ b/trading_intel/logging_utils.py
@@ -1,0 +1,15 @@
+import logging
+
+from .config import LOG_FILE
+
+
+def setup_logging() -> None:
+    """Configure the logging module.
+
+    Uses ``trading_intel.config.LOG_FILE`` for the log file path if set.
+    """
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        filename=LOG_FILE if LOG_FILE else None,
+    )

--- a/trading_intel/modeling.py
+++ b/trading_intel/modeling.py
@@ -7,13 +7,9 @@ import torch
 import torch.nn as nn
 from sklearn.model_selection import train_test_split
 
-from .config import DATABASE_URL, LOG_FILE
+from .config import DATABASE_URL
+from .logging_utils import setup_logging
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
-    filename=LOG_FILE if LOG_FILE else None,
-)
 logger = logging.getLogger(__name__)
 
 engine = sqlalchemy.create_engine(DATABASE_URL)
@@ -53,4 +49,5 @@ def train():
 
 
 if __name__ == "__main__":
+    setup_logging()
     train()

--- a/trading_intel/optimize.py
+++ b/trading_intel/optimize.py
@@ -5,34 +5,41 @@ import torch
 import torch.nn.utils.prune as prune
 import torch.quantization
 
-from .config import LOG_FILE
+from .logging_utils import setup_logging
 from .modeling import SimpleLSTM
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
-    filename=LOG_FILE if LOG_FILE else None,
-)
 logger = logging.getLogger(__name__)
 
-base_dir = Path(__file__).resolve().parent
-state = torch.load(base_dir / "lstm.pth")
-model = SimpleLSTM(input_dim=3)
-model.load_state_dict(state)
 
-prune.l1_unstructured(model.lstm, name="weight_ih_l0", amount=0.5)
-prune.remove(model.lstm, "weight_ih_l0")
+def main() -> None:
+    base_dir = Path(__file__).resolve().parent
+    state = torch.load(base_dir / "lstm.pth")
+    model = SimpleLSTM(input_dim=3)
+    model.load_state_dict(state)
 
-model.eval()
-supported = torch.backends.quantized.supported_engines
-backend = "fbgemm" if "fbgemm" in supported else "qnnpack"
-torch.backends.quantized.engine = backend
-print(f"Using quantization backend: {backend}")
-model.qconfig = torch.quantization.get_default_qconfig(backend)
-model_prepared = torch.quantization.prepare(model)
-model_prepared(torch.randn(1, 1, 3))
-model_int8 = torch.quantization.convert(model_prepared)
+    prune.l1_unstructured(model.lstm, name="weight_ih_l0", amount=0.5)
+    prune.remove(model.lstm, "weight_ih_l0")
 
-dummy = torch.randn(1, 1, 3)
-torch.onnx.export(model_int8, dummy, base_dir / "lstm_model.onnx", opset_version=13)
-logger.info("\u2705 ONNX export complete.")
+    model.eval()
+    supported = torch.backends.quantized.supported_engines
+    backend = "fbgemm" if "fbgemm" in supported else "qnnpack"
+    torch.backends.quantized.engine = backend
+    print(f"Using quantization backend: {backend}")
+    model.qconfig = torch.quantization.get_default_qconfig(backend)
+    model_prepared = torch.quantization.prepare(model)
+    model_prepared(torch.randn(1, 1, 3))
+    model_int8 = torch.quantization.convert(model_prepared)
+
+    dummy = torch.randn(1, 1, 3)
+    torch.onnx.export(
+        model_int8,
+        dummy,
+        base_dir / "lstm_model.onnx",
+        opset_version=13,
+    )
+    logger.info("\u2705 ONNX export complete.")
+
+
+if __name__ == "__main__":
+    setup_logging()
+    main()


### PR DESCRIPTION
## Summary
- add `setup_logging` helper
- use `setup_logging()` in scripts

## Testing
- `pre-commit run --files trading_intel/logging_utils.py trading_intel/ingestion.py trading_intel/features.py trading_intel/modeling.py trading_intel/inference.py trading_intel/optimize.py trading_intel/cli.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879d40f47e0832b9a3bc8d3d16f75eb