### PR TITLE
Add ti-cli entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,12 @@ Runs an hourly loop of data ingestion, feature creation and ONNX inference:
 ```bash
 python trading_intel/inference.py
 ```
-You can also schedule this loop via the CLI:
+You can also schedule this loop via the CLI. After installing the package in
+editable mode with `pip install -e .`, use the `ti-cli` entry point:
 ```bash
-python trading_intel/cli.py start   # add to crontab
-python trading_intel/cli.py stop    # remove from crontab
+ti-cli start    # add to crontab
+ti-cli stop     # remove from crontab
+ti-cli status   # show current crontab
 ```
 
 ## Development

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,5 +28,8 @@ dependencies = [
     "pytest",
 ]
 
+[project.scripts]
+ti-cli = "trading_intel.cli:main"
+
 [tool.setuptools]
 packages = ["trading_intel"]

--- a/trading_intel/cli.py
+++ b/trading_intel/cli.py
@@ -4,6 +4,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from typing import List, Optional
+
 from .config import LOG_FILE
 
 logging.basicConfig(
@@ -41,12 +43,26 @@ def status():
     logger.info("\U0001f4cb Crontab:\n%s", out.stdout)
 
 
-if __name__ == "__main__":
-    if len(sys.argv) < 2:
-        logger.error("usage: cli.py [start|stop|status]")
-    elif sys.argv[1] == "start":
-        start(sys.argv[2] if len(sys.argv) > 2 else None)
-    elif sys.argv[1] == "stop":
+def main(argv: Optional[List[str]] = None) -> int:
+    """Dispatch CLI commands."""
+    if argv is None:
+        argv = sys.argv[1:]
+    if not argv:
+        print("usage: ti-cli [start|stop|status]", file=sys.stderr)
+        return 1
+
+    cmd = argv[0]
+    if cmd == "start":
+        start()
+    elif cmd == "stop":
         stop()
-    else:
+    elif cmd == "status":
         status()
+    else:
+        print(f"unknown command: {cmd}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add main() dispatcher in `cli.py`
- expose the CLI as `ti-cli` script in pyproject
- document ti-cli usage in README

## Testing
- `pytest -vv`

------
https://chatgpt.com/codex/tasks/task_e_6879d40e217c832b8e2e1c4b47659760