### PR TITLE
Remove redundant ALPHAVANTAGE env var line

### DIFF
--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -2,7 +2,6 @@ import os
 
 import pandas as pd
 os.environ.setdefault("ALPHA_VANTAGE_API_KEY", "test")
-os.environ.setdefault("ALPHAVANTAGE_API_KEY", "test")
 import importlib  # noqa: E402
 
 import trading_intel.config as config  # noqa: E402


### PR DESCRIPTION
## Summary
- cleanup duplicate environment variable setting in tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6879d40d7f2c832bacd3bf8b9be6c99b