### PR TITLE
Improve feature creation error handling

### DIFF
--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,0 +1,19 @@
+import importlib
+
+import pandas as pd
+
+import trading_intel.config as config  # noqa: E402
+
+
+def reload_features(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "sqlite:///:memory:")
+    importlib.reload(config)
+    import trading_intel.features as features  # noqa: E402
+    return importlib.reload(features)
+
+
+def test_create_features_missing_tables(monkeypatch):
+    features = reload_features(monkeypatch)
+    df = features.create_features()
+    assert isinstance(df, pd.DataFrame)
+    assert df.empty

--- a/trading_intel/features.py
+++ b/trading_intel/features.py
@@ -2,6 +2,7 @@ import logging
 
 import pandas as pd
 import sqlalchemy
+from sqlalchemy.exc import DatabaseError
 from vaderSentiment.vaderSentiment import SentimentIntensityAnalyzer
 
 from .config import DATABASE_URL, LOG_FILE
@@ -34,7 +35,11 @@ def create_features():
           ON DATE_TRUNC('hour', p.timestamp) = DATE_TRUNC('hour', r.timestamp)
         ORDER BY p.timestamp
     """
-    df = pd.read_sql(query, engine)
+    try:
+        df = pd.read_sql(query, engine)
+    except DatabaseError as exc:  # tables may not exist
+        logger.error("Failed to read tables for features: %s", exc)
+        return pd.DataFrame()
     df["hour"] = df.timestamp.dt.hour
     df["price_diff"] = df.price.pct_change()
     df["ema_12"] = df.price.ewm(span=12).mean()


### PR DESCRIPTION
## Summary
- handle missing price or reddit tables when creating features
- add regression test for missing table logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879d40b85bc832b9aea6d561744e676