### PR TITLE
Use logger for quantization backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ model training and optimization.
 `optimize.py` automatically selects a quantization backend based on the
 engines available in `torch.backends.quantized.supported_engines`.
 If `fbgemm` is supported it will be used; otherwise `qnnpack` is selected.
-The chosen backend is printed when running the script.
+The chosen backend is logged when running the script.
 
 This project ingests price and social sentiment data, builds features, trains a model and exposes an inference loop.
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,3 @@
-import os
-
 import importlib  # noqa: E402
 
 import pytest  # noqa: E402

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -1,6 +1,7 @@
 import os
 
 import pandas as pd
+
 os.environ.setdefault("ALPHA_VANTAGE_API_KEY", "test")
 os.environ.setdefault("ALPHAVANTAGE_API_KEY", "test")
 import importlib  # noqa: E402

--- a/trading_intel/optimize.py
+++ b/trading_intel/optimize.py
@@ -27,12 +27,17 @@ model.eval()
 supported = torch.backends.quantized.supported_engines
 backend = "fbgemm" if "fbgemm" in supported else "qnnpack"
 torch.backends.quantized.engine = backend
-print(f"Using quantization backend: {backend}")
+logger.info("Using quantization backend: %s", backend)
 model.qconfig = torch.quantization.get_default_qconfig(backend)
 model_prepared = torch.quantization.prepare(model)
 model_prepared(torch.randn(1, 1, 3))
 model_int8 = torch.quantization.convert(model_prepared)
 
 dummy = torch.randn(1, 1, 3)
-torch.onnx.export(model_int8, dummy, base_dir / "lstm_model.onnx", opset_version=13)
+torch.onnx.export(
+    model_int8,
+    dummy,
+    base_dir / "lstm_model.onnx",
+    opset_version=13,
+)
 logger.info("\u2705 ONNX export complete.")


### PR DESCRIPTION
## Summary
- replace `print` with `logger.info` in `optimize.py`
- note that quantization backend is logged in README
- run formatting hooks

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879d40890d0832b93a3183649016969