### PR TITLE
Move pytest to optional dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,10 @@ dependencies = [
     "scikit-learn",
     "torch",
     "onnxruntime",
-    "pytest",
 ]
+
+[project.optional-dependencies]
+dev = ["pytest"]
 
 [project.scripts]
 ti-cli = "trading_intel.cli:main"

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,6 @@ vaderSentiment
 scikit-learn
 torch
 onnxruntime
-pytest
 black
 flake8
 isort


### PR DESCRIPTION
## Summary
- remove `pytest` from runtime dependencies
- add `[project.optional-dependencies.dev]` entry for `pytest`
- update `requirements.txt` to match

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'trading_intel')*

------
https://chatgpt.com/codex/tasks/task_e_687a54c07828832bb5313f46bed93586