### PR TITLE
Remove unused ts and reddit instances

### DIFF
--- a/trading_intel/ingestion.py
+++ b/trading_intel/ingestion.py
@@ -15,12 +15,6 @@ from .logging_utils import setup_logging
 logger = logging.getLogger(__name__)
 
 engine = sqlalchemy.create_engine(DATABASE_URL)
-ts = TimeSeries(key=API_KEYS["ALPHA_VANTAGE"], output_format="pandas")
-reddit = Reddit(
-    client_id=API_KEYS["REDDIT_CLIENT_ID"],
-    client_secret=API_KEYS["REDDIT_CLIENT_SECRET"],
-    user_agent="ti-app",
-)
 
 
 def _handle_error(msg: str, exc: Exception) -> None:


### PR DESCRIPTION
## Summary
- trim unused objects from `trading_intel.ingestion`

## Testing
- `PYTHONPATH=. pytest -q` *(fails: No module named 'alpha_vantage', torch OSError)*

------
https://chatgpt.com/codex/tasks/task_e_687a5e67b6d4832ba7d27f4975aa6902