### PR TITLE
Add Apple Silicon note for psycopg2

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ conda install pytorch onnxruntime -c pytorch -c conda-forge
 Some Python versions may not have pre-built wheels available, requiring a
 source build of one or both packages.
 
+`psycopg2-binary` may also lack pre-built wheels on Apple Silicon. Install
+PostgreSQL headers (e.g., `brew install postgresql`) and build `psycopg2` from
+source:
+```bash
+pip install psycopg2
+```
+
 ## Usage
 ### Ingestion
 Downloads crypto, stock, on-chain and reddit data and writes them to the database:


### PR DESCRIPTION
## Summary
- document building psycopg2 on Apple Silicon

## Testing
- `pre-commit run --files README.md`
- `pytest -q` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_687b22b4f06c832bb4dbbe2f0c4ec351