### PR TITLE
Add dev install step to README testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,10 @@ pre-commit run --all-files
 ```
 
 ### Testing
-Execute the unit tests with `pytest`:
+Install the package with development dependencies and run the tests:
 
 ```bash
+pip install -e .[dev]
 pytest
 ```
 


### PR DESCRIPTION
## Summary
- update README testing steps to install development dependencies before running tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'trading_intel')*

------
https://chatgpt.com/codex/tasks/task_e_687b22adc728832b8180f08f46da890b