### PR TITLE
Add DB init module

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ This project ingests price and social sentiment data, builds features, trains a 
    - `FRED_API_KEY`
    - `REDDIT_CLIENT_ID`
    - `REDDIT_CLIENT_SECRET`
+4. Initialize the database tables (run once before ingestion):
+   ```bash
+   python -m trading_intel.init_db
+   ```
 
 ### Apple Silicon (M-series)
 Torch and ONNXRuntime wheels for macOS on Apple Silicon are often CPU only. If

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -1,8 +1,8 @@
+import asyncio
 import os
 import sys
 
 import pandas as pd
-import asyncio
 
 os.environ.setdefault("ALPHA_VANTAGE_API_KEY", "test")
 os.environ.setdefault("FRED_API_KEY", "test")

--- a/trading_intel/ingestion.py
+++ b/trading_intel/ingestion.py
@@ -1,7 +1,7 @@
+import asyncio
 import logging
 import time
 from datetime import datetime
-import asyncio
 
 import pandas as pd
 import requests

--- a/trading_intel/init_db.py
+++ b/trading_intel/init_db.py
@@ -1,0 +1,58 @@
+import logging
+
+import sqlalchemy
+from sqlalchemy import (
+    Column,
+    DateTime,
+    Float,
+    Integer,
+    MetaData,
+    String,
+    Table,
+)
+
+from .config import DATABASE_URL, validate_env
+from .logging_utils import setup_logging
+
+logger = logging.getLogger(__name__)
+engine = sqlalchemy.create_engine(DATABASE_URL)
+metadata = MetaData()
+
+price_data = Table(
+    "price_data",
+    metadata,
+    Column("id", Integer, primary_key=True),
+    Column("timestamp", DateTime, index=True),
+    Column("open", Float),
+    Column("high", Float),
+    Column("low", Float),
+    Column("close", Float),
+    Column("volume", Float),
+    Column("price", Float),
+    Column("dividends", Float),
+    Column("stock_splits", Float),
+    Column("symbol", String(50), nullable=False),
+    Column("type", String(50), nullable=False),
+)
+
+reddit_data = Table(
+    "reddit_data",
+    metadata,
+    Column("id", String(30), primary_key=True),
+    Column("timestamp", DateTime, index=True),
+    Column("title", String),
+    Column("selftext", String),
+    Column("sub", String(100)),
+)
+
+
+def create_tables() -> None:
+    """Create database tables defined in this module."""
+    metadata.create_all(engine)
+    logger.info("\u2705 Database tables created.")
+
+
+if __name__ == "__main__":
+    validate_env()
+    setup_logging()
+    create_tables()


### PR DESCRIPTION
## Summary
- add module for initializing database tables
- document running `init_db` before ingesting data

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: ModuleNotFoundError due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687b22b0f71c832b8158c9ece9050412